### PR TITLE
fix: execute `bundle lock --add-platform x86_64-linux`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   byebug


### PR DESCRIPTION
ref: https://github.com/MH4GF/graphql-ruby-constraint-directive/actions/runs/3828542908/jobs/6514251785
